### PR TITLE
FIX: patch for mpl3.1+ compat

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,10 +9,12 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - mpl31.patch
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/mpl31.patch
+++ b/recipe/mpl31.patch
@@ -1,0 +1,16 @@
+diff --git a/modest_image/modest_image.py b/modest_image/modest_image.py
+index ef257b9..ab4d614 100644
+--- a/modest_image/modest_image.py
++++ b/modest_image/modest_image.py
+@@ -210,8 +210,9 @@ def imshow(axes, X, cmap=None, norm=None, aspect=None,
+ 
+     Unlike matplotlib version, must explicitly specify axes
+     """
+-    if not axes._hold:
+-        axes.cla()
++    # This does not work with the latest matplotlib 3.1+, comenting it out:
++    # if not axes._hold:
++    #     axes.cla()
+     if norm is not None:
+         assert(isinstance(norm, mcolors.Normalize))
+     if aspect is None:


### PR DESCRIPTION
the (private) `Axes._hold` attribute was deprecated and removed.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
